### PR TITLE
Fix prebuffer storage length (#160)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fridgefm/radio-core",
   "author": "Grigory Gorshkov",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "internet radio engine made on NodeJS platform",
   "license": "MIT",
   "main": "./lib/index.js",

--- a/src/features/Prebuffer.ts
+++ b/src/features/Prebuffer.ts
@@ -17,7 +17,7 @@ export class Prebuffer {
 
   public modify(chunks: Buffer[]) {
     chunks.forEach((ch) => {
-      if (this._storage.length > this._prebufferLength) {
+      if (this._storage.length >= this._prebufferLength) {
         this._storage.shift();
       }
 

--- a/src/features/__tests__/Prebuffer.test.ts
+++ b/src/features/__tests__/Prebuffer.test.ts
@@ -23,10 +23,10 @@ describe('features/Prebuffer', () => {
 
     // overflow - the length stays the same
     instance.modify(createChunks('1234'));
-    expect(instance.getStorage().join('')).toEqual('4567890123');
+    expect(instance.getStorage().join('')).toEqual('5678901234');
 
     instance.modify(createChunks('1234'));
-    expect(instance.getStorage().join('')).toEqual('8901234123');
+    expect(instance.getStorage().join('')).toEqual('9012341234');
   });
 
   it('uses default if length not set', () => {


### PR DESCRIPTION
Affects https://github.com/ch1ller0/fridgefm-radio-core/issues/160
This fix makes `prebuffer.getStorage` method return value containing the last added chunk. It is hard to believe that previous logic made your radio miss a whole chunk between switching from prebuffer to actual stream. However, it does not fully solve the issue with syncing